### PR TITLE
Fix issue where nvim ignored wrong directory

### DIFF
--- a/xdg_config/nvim/.gitignore
+++ b/xdg_config/nvim/.gitignore
@@ -1,1 +1,1 @@
-plugin
+plugin/packer_compiled.lua


### PR DESCRIPTION
For some reason, this was causing telescope to ignore after/plugin as well..

Fixes #3 

TODO: Should look if this is something fixable in treesitter before merging...